### PR TITLE
feat: display name and size from gateway metadata file

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -40,7 +40,7 @@ body {
 	opacity: 0 !important;
 }
 
-textarea, 
+textarea,
 #texteditor {
 	background-color: #fff;
 	width: 100%;
@@ -57,9 +57,25 @@ textarea,
 	white-space: pre-wrap;
 }
 
+.metadata{
+	font-family: monospace;
+	margin-top: 25px;
+}
+
+.metadata .name{
+	font-weight: bold;
+	color: white;
+	padding-right: 10px;
+}
+
+.metadata .size{
+	font-style: italic;
+	color: #efefef;
+}
+
 #texteditor[placeholder]:empty:before {
     content: attr(placeholder);
-    color: #888; 
+    color: #888;
 }
 
 #logo {
@@ -350,7 +366,7 @@ textarea,
 		width: 100%;
 	}
 
-	textarea, 
+	textarea,
 	#texteditor {
 		padding: 10px;
 		padding-top: 10px;
@@ -391,7 +407,7 @@ textarea,
     background-size: 1000px;
   }
 
-  textarea, 
+  textarea,
 	#texteditor {
 		/*min-height: calc(100vh - 200px - 156px - 70px - 75px - 50px);*/
 		min-height: calc(100vh - 200px - 156px - 80px);

--- a/assets/index.js
+++ b/assets/index.js
@@ -1,8 +1,10 @@
-let gateway = 'https://bee-0.gateway.ethswarm.org'
-let h = window.location.href;
-let r = h.split(h.match(/\?/),h.length)[1];
+const GATEWAY = 'https://bee-0.gateway.ethswarm.org'
+const META_FILE_NAME = '.swarmgatewaymeta.json'
 
-let loaded,hash, hasPaste, pasteText, url, showingAbout;
+let h = window.location.href;
+let parsedHash = h.split(h.match(/\?/),h.length)[1];
+
+let hash, hasPaste, metadata, pasteText, url, showingAbout;
 
 let baseHash;
 let href = window.location.href.split('/');
@@ -10,43 +12,64 @@ if(href.indexOf('bzz') > -1){
      baseHash = href[4];
 }
 
+const shortenBytes = (value) => {
+    if (value < 1e3) return `${value} bytes`
+
+    if (value < 1e6) return `${(value / 1e3).toFixed(2)} kB`
+
+    return `${(value / 1e6).toFixed(2)} MB`
+}
+
 let init = async () => {
 
     showAbout = false;
 
-    if(typeof r === 'undefined'){
+    if(typeof parsedHash === 'undefined'){
         hash = '';
         pasteText = '';
         url = '';
         hasPaste = false;
     }else{
-        hash = r;
+        hash = parsedHash;
         url = window.location.href;
         hasPaste = true;
-        await axios.get(gateway + '/bzz/' + r).then((r_)=>{
+        await axios.get(GATEWAY + '/bzz/' + parsedHash).then((r_)=>{
             pasteText = r_.data;
             document.getElementById('texteditor').textContent = pasteText
         });
+
+        // Fetch metadata file
+        await axios.get(GATEWAY + '/bzz/' + parsedHash + '/' + META_FILE_NAME).then((r_)=>{
+            metadata = r_.data;
+        }).catch(e => {
+            // If not found, than we ignore, otherwise at least propagate to console
+            if ( !e.response || e.response.status !== 404) {
+                console.error(e)
+            }
+        });
     }
-    
+
     const router = new VueRouter({
       base: '/',
       mode: 'history',
       // routes: routes
     });
 
+    Vue.filter('shortenBytes', shortenBytes)
+
     let app = new Vue({
         router: router,
         el: '#app',
         data: {
+            metadata: metadata,
             hasPaste: hasPaste,
             pasteText: pasteText,
             showingAbout: showingAbout,
             hash: hash,
             url: url,
             gatewayLink: function(){
-                return gateway + '/bzz/' + this.hash 
-            } 
+                return GATEWAY + '/bzz/' + this.hash
+            }
         },
         methods: {
             clearPasteText: function(){
@@ -55,13 +78,14 @@ let init = async () => {
             createPaste: async function(){
                 let formData = new FormData();
                 // formData.append('pastebee.com.txt', this.pasteText);
-                let response = await axios.post(gateway + '/bzz?name=pastebee.com.txt', this.pasteText)
+                let response = await axios.post(GATEWAY + '/bzz?name=pastebee.com.txt', this.pasteText)
                 this.hash = response.data.reference;
                 this.hasPaste = true;
                 document.getElementById('texteditor').textContent = this.pasteText
                 let h_ = window.location.href.split('?')[0] + '?' + this.hash;
                 this.url = h_;
                 window.history.pushState({path:h_},'',h_);
+                this.metadata = undefined
             },
             resetPaste: function(){
                 this.pasteText = '';
@@ -86,7 +110,7 @@ let init = async () => {
                     contentEl.classList.remove('rotate-out-center');
                     pageEl.classList.remove('fade-out');
                 }, 1000);
-                
+
             },
             onInput: function(e){
                 this.pasteText = e.target.innerText;

--- a/index.html
+++ b/index.html
@@ -31,17 +31,20 @@
 						</router-link>
 						<a class="desktop-only" id="powered-by-swarm" href="https://www.ethswarm.org/" target="_blank"></a>
 					</div>
-				
+
 
 				<router-view>
-					
+
 				</router-view>
 
 				<!-- output -->
 				<div class="show-paste" v-show="hasPaste">
-<!-- 					<h3>Paste {{hash}}</h3> -->
 					<input class="copy-input" id="copy-input-1" :value="url" readonly>
 					<button id="copy" v-on:click="copyUrl"></button>
+					<div class="metadata" v-if="metadata">
+						<span class="name">{{metadata.name}}</span>
+						<span class="size">{{metadata.size | shortenBytes}}</span>
+					</div>
 					<!-- output -->
 					<div>
 						<div contentEditable="true" id="texteditor" placeholder="Paste text here..." @input="onInput"></div>


### PR DESCRIPTION
If the data is uploaded using Gateway or `pastebee-cli` then there is metadata JSON file that contain name, file size and file type. This PR adds support for displaying name and file size.

Feel free to try it with hash `5d176bedb53193962914e492866dee162e8cc96365441594f29fee02066edce1`. If you want to tweak the design feel free.

![image](https://user-images.githubusercontent.com/6072250/137935602-bc0a2c17-61dc-461f-ab3b-ac3cf286b77d.png)
